### PR TITLE
modify to use ash in Alpine Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Dockerfile to configure Common Lisp execution environment based on Alpine Linu
 
 ```bash
 $ docker pull eshamster/cl-base
-$ docker run -v <a host folder>:/home/dev/work/lisp -it eshamster/cl-base /bin/bash
+$ docker run -v <a host folder>:/home/dev/work/lisp -it eshamster/cl-base /bin/ash
 ```
 
 Note: `/home/dev/work/lisp` is a sym-link to `/home/dev/.roswell/local-projects`


### PR DESCRIPTION
```bash
$ docker run -v /Users/tamura-shingo/lisp:/home/dev/work/lisp -it eshamster/cl-base /bin/bash
docker: Error response from daemon: OCI runtime create failed: container_linux.go:344: starting container process caused "exec: \"/bin/bash\": stat /bin/bash: no such file or directory": unknown.

$ docker run -v /Users/tamura-shingo/lisp:/home/dev/work/lisp -it eshamster/cl-base /bin/ash
/ #
```
